### PR TITLE
Update oauthswift usage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-
 github "Thomvis/BrightFutures"
 github "OAuthSwift/OAuthSwift" "master"

--- a/Sources/OAuthSwift+BrightFutures.swift
+++ b/Sources/OAuthSwift+BrightFutures.swift
@@ -39,7 +39,7 @@ extension OAuth1Swift {
 
         let promise = Promise<FutureSuccess, FutureError>()
         
-        let handle = self.authorize(
+        let handle = authorize(
             withCallbackURL: callbackURL,
             success: { credential, response, parameters in
                 promise.success((credential, response, parameters))
@@ -60,7 +60,7 @@ extension OAuth2Swift {
 
         let promise = Promise<FutureSuccess, FutureError>()
         
-         let handle = self.authorize(
+         let handle = authorize(
             withCallbackURL: callbackURL, scope: scope, state: state, parameters: parameters, headers: headers,
             success: { credential, response, parameters in
                 promise.success((credential, response, parameters))
@@ -77,7 +77,7 @@ extension OAuth2Swift {
         
         let promise = Promise<FutureSuccess, FutureError>()
         
-        let handle = self.authorize(
+        let handle = authorize(
             withCallbackURL: callbackURL, scope: scope, state: state, parameters: parameters, headers: headers,
             success: { credential, response, parameters in
                 promise.success((credential, response, parameters))

--- a/Sources/OAuthSwift+BrightFutures.swift
+++ b/Sources/OAuthSwift+BrightFutures.swift
@@ -11,7 +11,7 @@ import OAuthSwift
 import BrightFutures
 
 extension OAuthSwift {
-    public typealias FutureSuccess = (credential: OAuthSwiftCredential, response: URLResponse?, parameters: OAuthSwift.Parameters) // see OAuthSwift.TokenSuccessHandler
+    public typealias FutureSuccess = (credential: OAuthSwiftCredential, response: OAuthSwiftResponse?, parameters: OAuthSwift.Parameters) // see OAuthSwift.TokenSuccessHandler
     public typealias FutureError = OAuthSwiftError
     public typealias FutureResult = (future: Future<FutureSuccess, FutureError>, handle: OAuthSwiftRequestHandle?)
 }
@@ -21,13 +21,13 @@ extension OAuth1Swift {
     
     open func authorizeFuture(withCallbackURL callbackURL: String) -> FutureResult {
         let promise = Promise<FutureSuccess, FutureError>()
-        
-        let handle = self.authorize(
+
+        let handle = authorize(
             withCallbackURL: callbackURL,
             success: { credential, response, parameters in
                 promise.success((credential, response, parameters))
             },
-            failure:{ error in
+            failure: { error in
                 promise.failure(error)
             }
         )

--- a/Sources/OAuthSwiftClient+BrightFutures.swift
+++ b/Sources/OAuthSwiftClient+BrightFutures.swift
@@ -18,29 +18,29 @@ extension OAuthSwiftClient {
     public typealias FutureResult = (future: Future<FutureSuccess, FutureError>, handle: OAuthSwiftRequestHandle?)
 
     public func getFuture(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
-        return self.requestFuture(urlString, method: .GET, parameters: parameters, headers: headers)
+        return requestFuture(urlString, method: .GET, parameters: parameters, headers: headers)
     }
 
     public func postFuture(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
-        return self.requestFuture(urlString, method: .POST, parameters: parameters, headers: headers)
+        return requestFuture(urlString, method: .POST, parameters: parameters, headers: headers)
     }
 
     public func putFuture(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
-        return self.requestFuture(urlString, method: .PUT, parameters: parameters, headers: headers)
+        return requestFuture(urlString, method: .PUT, parameters: parameters, headers: headers)
     }
 
     public func deleteFuture(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
-        return self.requestFuture(urlString, method: .DELETE, parameters: parameters, headers: headers)
+        return requestFuture(urlString, method: .DELETE, parameters: parameters, headers: headers)
     }
 
     public func patchFuture(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
-        return self.requestFuture(urlString, method: .PATCH, parameters: parameters, headers: headers)
+        return requestFuture(urlString, method: .PATCH, parameters: parameters, headers: headers)
     }
 
     public func requestFuture(_ url: String, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
        
         let promise = Promise<FutureSuccess, FutureError>()
-        let handle = self.request(
+        let handle = request(
             url, method: method, parameters: parameters, headers: headers,
             success: { response in
                 promise.success(response)
@@ -57,7 +57,7 @@ extension OAuthSwiftClient {
         
         let promise = Promise<FutureSuccess, FutureError>()
 
-        let handle = self.postImage(
+        let handle = postImage(
             urlString, parameters: parameters, image: image,
             success: { response in
                 promise.success(response)
@@ -73,7 +73,7 @@ extension OAuthSwiftClient {
         
         let promise = Promise<FutureSuccess, FutureError>()
 
-        let handle = self.postMultiPartRequest(url, method: method, parameters: parameters, multiparts: multiparts ,
+        let handle = postMultiPartRequest(url, method: method, parameters: parameters, multiparts: multiparts ,
             success: {response in
                 promise.success(response)
             }, failure: { error in

--- a/Sources/OAuthSwiftClient+BrightFutures.swift
+++ b/Sources/OAuthSwiftClient+BrightFutures.swift
@@ -13,7 +13,7 @@ import BrightFutures
 
 extension OAuthSwiftClient {
 
-    public typealias FutureSuccess = (data: Data, response: HTTPURLResponse)
+    public typealias FutureSuccess = OAuthSwiftResponse
     public typealias FutureError = OAuthSwiftError
     public typealias FutureResult = (future: Future<FutureSuccess, FutureError>, handle: OAuthSwiftRequestHandle?)
 
@@ -40,11 +40,10 @@ extension OAuthSwiftClient {
     public func requestFuture(_ url: String, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil) -> FutureResult {
        
         let promise = Promise<FutureSuccess, FutureError>()
-
         let handle = self.request(
             url, method: method, parameters: parameters, headers: headers,
-            success: { data, response in
-                promise.success((data: data, response: response))
+            success: { response in
+                promise.success(response)
             },
             failure: { error in
                 promise.failure(error)
@@ -60,8 +59,8 @@ extension OAuthSwiftClient {
 
         let handle = self.postImage(
             urlString, parameters: parameters, image: image,
-            success: { data, response in
-                promise.success((data: data, response: response))
+            success: { response in
+                promise.success(response)
             },
             failure: { error in
                 promise.failure(error)
@@ -75,8 +74,8 @@ extension OAuthSwiftClient {
         let promise = Promise<FutureSuccess, FutureError>()
 
         let handle = self.postMultiPartRequest(url, method: method, parameters: parameters, multiparts: multiparts ,
-            success: {data, response in
-                promise.success((data: data, response: response))
+            success: {response in
+                promise.success(response)
             }, failure: { error in
                 promise.failure(error)
             }


### PR DESCRIPTION
OAuthSwift has moved to the usage of `OAuthSwiftResponse` in their callbacks. This PR brings the implementation of OAuthSwiftFutures up to date with the changes in master.